### PR TITLE
Dashboard Clock field: Add Battery percentage

### DIFF
--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -63,7 +63,7 @@ struct NodePrefs {  // persisted to file
   struct DmNotifEntry { uint8_t prefix[4]; uint8_t state; }; // state: 0=default,1=muted,2=force-on
   static const int DM_NOTIF_TABLE_MAX = 16;
   DmNotifEntry dm_notif[DM_NOTIF_TABLE_MAX]; // 16*5 = 80 bytes
-  uint8_t  dashboard_fields[3]; // 0=None,1=Batt,2=Temp,3=Hum,4=Pres,5=GPS,6=Alt,7=Lux,8=CO2,9=Nodes
+  uint8_t  dashboard_fields[3]; // 0=None,1=Batt V,2=Temp,3=Hum,4=Pres,5=GPS,6=Alt,7=Lux,8=CO2,9=Nodes,10=Msgs,11=Batt %
   uint32_t advert_auto_interval_sec; // periodic 0-hop advert with GPS: 0=off, else seconds
   // Second melody slot (same packing as ringtone_*)
   uint8_t  ringtone2_bpm_idx;

--- a/examples/companion_radio/ui-new/DashboardConfigScreen.h
+++ b/examples/companion_radio/ui-new/DashboardConfigScreen.h
@@ -3,18 +3,19 @@
 // Included by UITask.cpp after BotScreen.h.
 
 // Field type constants — used here and in UITask.cpp HP_CLOCK render.
-static const uint8_t DASH_NONE   = 0;
-static const uint8_t DASH_BATT   = 1;
-static const uint8_t DASH_TEMP   = 2;
-static const uint8_t DASH_HUM    = 3;
-static const uint8_t DASH_PRES   = 4;
-static const uint8_t DASH_GPS    = 5;
-static const uint8_t DASH_ALT    = 6;
-static const uint8_t DASH_LUX    = 7;
-static const uint8_t DASH_CO2    = 8;
-static const uint8_t DASH_NODES  = 9;
-static const uint8_t DASH_MSGS   = 10;
-static const uint8_t DASH_COUNT  = 11;
+static const uint8_t DASH_NONE    = 0;
+static const uint8_t DASH_BATT_V  = 1;
+static const uint8_t DASH_TEMP    = 2;
+static const uint8_t DASH_HUM     = 3;
+static const uint8_t DASH_PRES    = 4;
+static const uint8_t DASH_GPS     = 5;
+static const uint8_t DASH_ALT     = 6;
+static const uint8_t DASH_LUX     = 7;
+static const uint8_t DASH_CO2     = 8;
+static const uint8_t DASH_NODES   = 9;
+static const uint8_t DASH_MSGS    = 10;
+static const uint8_t DASH_BATT_PCT = 11;
+static const uint8_t DASH_COUNT   = 12;
 
 class DashboardConfigScreen : public UIScreen {
   UITask*    _task;
@@ -79,6 +80,6 @@ public:
 };
 
 const char* DashboardConfigScreen::OPTION_NAMES[DASH_COUNT] = {
-  "None", "Battery", "Temp", "Humidity", "Pressure",
-  "GPS", "Altitude", "Lux", "CO2", "Contacts", "Messages"
+  "None", "Batt V", "Temp", "Humidity", "Pressure",
+  "GPS", "Altitude", "Lux", "CO2", "Contacts", "Messages", "Batt %"
 };

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -549,11 +549,29 @@ public:
             label[0] = '\0';
             val[0] = '\0';
 
-            if (field == DASH_BATT) {
+            if (field == DASH_BATT_V) {
               strcpy(label, "Batt");
               uint16_t mv = _task->getBattMilliVolts();
               if (mv > 0) snprintf(val, sizeof(val), "%u.%02uV", mv/1000, (mv%1000)/10);
               else strcpy(val, "--");
+            } else if (field == DASH_BATT_PCT) {
+              strcpy(label, "Batt");
+              uint16_t mv = _task->getBattMilliVolts();
+              if (mv > 0) {
+                // Simple linear voltage to percentage calculation
+                #ifndef BATT_MIN_MILLIVOLTS
+                #define BATT_MIN_MILLIVOLTS 3000
+                #endif
+                #ifndef BATT_MAX_MILLIVOLTS
+                #define BATT_MAX_MILLIVOLTS 4200
+                #endif
+                int percent = ((mv - BATT_MIN_MILLIVOLTS) * 100) / (BATT_MAX_MILLIVOLTS - BATT_MIN_MILLIVOLTS);
+                if (percent < 0) percent = 0;
+                if (percent > 100) percent = 100;
+                snprintf(val, sizeof(val), "%d%%", percent);
+              } else {
+                strcpy(val, "--");
+              }
             } else if (field == DASH_GPS) {
               strcpy(label, "GPS");
 #if ENV_INCLUDE_GPS == 1
@@ -1424,9 +1442,25 @@ static void formatDashVal(uint8_t field, char* val, int val_len, uint16_t batt_m
   val[0] = '\0';
   switch (field) {
     case DASH_NONE: return;
-    case DASH_BATT:
+    case DASH_BATT_V:
       if (batt_mv > 0) snprintf(val, val_len, "%u.%02uV", batt_mv/1000, (batt_mv%1000)/10);
       else              strcpy(val, "--");
+      return;
+    case DASH_BATT_PCT:
+      if (batt_mv > 0) {
+        #ifndef BATT_MIN_MILLIVOLTS
+        #define BATT_MIN_MILLIVOLTS 3000
+        #endif
+        #ifndef BATT_MAX_MILLIVOLTS
+        #define BATT_MAX_MILLIVOLTS 4200
+        #endif
+        int percent = ((batt_mv - BATT_MIN_MILLIVOLTS) * 100) / (BATT_MAX_MILLIVOLTS - BATT_MIN_MILLIVOLTS);
+        if (percent < 0) percent = 0;
+        if (percent > 100) percent = 100;
+        snprintf(val, val_len, "%d%%", percent);
+      } else {
+        strcpy(val, "--");
+      }
       return;
     case DASH_NODES:
       snprintf(val, val_len, "%d nodes", the_mesh.getNumContacts());


### PR DESCRIPTION
This is adding the possibility to have a dashboard - clock field - Voltage displayed as % or V. I kept the enums the same for compatibility, which means that Batt % and Batt V are far away from each other in the options. I also kept the label the same ("Batt"), but it could be Batt V and Batt %.

AI disclosure: this is Mistral's coding agent called Vibe, with my edits. Do you want me to add the "Co-Authored-By:..." into commit message?

<img width="536" height="280" alt="screenshot_2026-05-27_22-59-32" src="https://github.com/user-attachments/assets/d3924375-2154-4fc8-8c20-1e3f14749a19" />
