### PR TITLE
Faketec/Promicro enablement and fixes/improvements

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -568,6 +568,10 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
   // behaviour for upgraders).
   rd(&_prefs.keyboard_cardkb_compact, sizeof(_prefs.keyboard_cardkb_compact));
   if (_prefs.keyboard_cardkb_compact > 1) _prefs.keyboard_cardkb_compact = 0;
+  // → 0xC0DE0024: persist board.setAdcMultiplier()'s value. A pre-0x24 file
+  // has no bytes here; _prefs.adc_multiplier stays at its zero-init default,
+  // which is exactly "no override".
+  rd(&_prefs.adc_multiplier, sizeof(_prefs.adc_multiplier));
 
   // Schema sentinel: bumped on layout changes. Mismatch means an older file
   // (or a different schema); rd() already zero-inits any fields not present,
@@ -781,6 +785,7 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     file.write((uint8_t *)&_prefs.gpio3_mode, sizeof(_prefs.gpio3_mode));
     file.write((uint8_t *)&_prefs.gpio4_mode, sizeof(_prefs.gpio4_mode));
     file.write((uint8_t *)&_prefs.keyboard_cardkb_compact, sizeof(_prefs.keyboard_cardkb_compact));
+    file.write((uint8_t *)&_prefs.adc_multiplier, sizeof(_prefs.adc_multiplier));
 
     // Tail sentinel — must be last. See NodePrefs::SCHEMA_SENTINEL. Its write is
     // the one we check: once the flash fills, writes return 0, so a good

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1701,6 +1701,10 @@ void MyMesh::begin(bool has_display) {
   _prefs.tx_power_dbm = constrain(_prefs.tx_power_dbm, -9, MAX_LORA_TX_POWER);
   _prefs.gps_enabled = constrain(_prefs.gps_enabled, 0, 1);  // Ensure boolean 0 or 1
   _prefs.gps_interval = constrain(_prefs.gps_interval, 0, 86400);  // Max 24 hours
+  // Apply the persisted ADC multiplier. 0.0f already means "use hardware
+  // default" to setAdcMultiplier() itself, so always safe to call.
+  if (isnan(_prefs.adc_multiplier) || isinf(_prefs.adc_multiplier)) _prefs.adc_multiplier = 0.0f;
+  board.setAdcMultiplier(_prefs.adc_multiplier);
 
 #ifdef BLE_PIN_CODE // 123456 by default
   if (_prefs.ble_pin == 0) {
@@ -2606,8 +2610,21 @@ void MyMesh::handleCmdFrame(size_t len) {
       strcpy(dp, sensors.getSettingName(i));
       dp = strchr(dp, 0);
       *dp++ = ':';
-      strcpy(dp, sensors.getSettingValue(i));
+            strcpy(dp, sensors.getSettingValue(i));
       dp = strchr(dp, 0);
+    }
+    // Board-level ADC calibration, not a sensor setting -- route directly.
+    // getAdcMultiplier() returns 0.0f on boards that don't implement calibration.
+    {
+      float am = board.getAdcMultiplier();
+      if (am != 0.0f && dp - (char *)&out_frame[1] < 120) {
+        if (dp != (char *)&out_frame[1]) *dp++ = ',';
+        strcpy(dp, "adc.multiplier");
+        dp = strchr(dp, 0);
+        *dp++ = ':';
+        sprintf(dp, "%.3f", am);
+        dp = strchr(dp, 0);
+      }
     }
     _serial->writeFrame(out_frame, dp - (char *)out_frame);
   } else if (cmd_frame[0] == CMD_SET_CUSTOM_VAR && len >= 4) {
@@ -2616,8 +2633,20 @@ void MyMesh::handleCmdFrame(size_t len) {
     char *np = strchr(sp, ':'); // look for separator char
     if (np) {
       *np++ = 0; // modify 'cmd_frame', replace ':' with null
-      bool success = sensors.setSettingValue(sp, np);
+      bool success;
+      if (strcmp(sp, "adc.multiplier") == 0) {
+        // Board-level ADC calibration, not a sensor setting -- route directly.
+        // setAdcMultiplier() returns false on boards that don't support it.
+        float multiplier = atof(np);
+        success = board.setAdcMultiplier(multiplier);
+      } else {
+        success = sensors.setSettingValue(sp, np);
+      }
       if (success) {
+        if (strcmp(sp, "adc.multiplier") == 0) {
+          _prefs.adc_multiplier = atof(np);
+          savePrefs();
+        }
         #if ENV_INCLUDE_GPS == 1
         // Update node preferences for GPS settings
         if (strcmp(sp, "gps") == 0) {

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -440,6 +440,11 @@ struct NodePrefs {  // persisted to file
   // stays put even if the module is briefly unplugged. Default 0 (full grid,
   // unchanged behaviour) on upgrade.
   uint8_t  keyboard_cardkb_compact;
+    // Board-level ADC calibration (see board.getAdcMultiplier()/setAdcMultiplier()
+  // -- CommonCLI's adc.multiplier). 0.0f means "no override, use the board's
+  // hardware-default ADC_MULTIPLIER constant". Default 0.0f (unchanged
+  // behaviour) on upgrade.
+  float    adc_multiplier;
 
   // Single source of truth for the live-share option tables (shared by the Map
   // UI labels and the auto-send engine in UITask).
@@ -503,7 +508,7 @@ struct NodePrefs {  // persisted to file
   // adding/removing/reordering fields in DataStore::savePrefs/loadPrefsInt so
   // older saves are detected on load and skipped (zero-init defaults kept).
   // High 24 bits identify the file format; low byte is the schema revision.
-  static const uint32_t SCHEMA_SENTINEL = 0xC0DE0023;
+  static const uint32_t SCHEMA_SENTINEL = 0xC0DE0024;
 
   // Bit-index for each home page. Used by page_order (entries store bit+1) and
   // by home_pages_mask. Single source of truth — both HomeScreen::pageBit/bitToPage
@@ -608,7 +613,7 @@ struct NodePrefs {  // persisted to file
 // bumps, 7 more uint8_t total) added 8 bytes, not 7 -- one byte of tail
 // padding got consumed along the way. 2720 confirmed via a real
 // WioTrackerL1Eink_companion_solo_dual build.
-static_assert(sizeof(NodePrefs) == 2720,
+  static_assert(sizeof(NodePrefs) == 2728,
               "NodePrefs layout changed — sync DataStore save/load + clamp, bump "
               "SCHEMA_SENTINEL, then update this size (see steps above).");
 

--- a/examples/companion_radio/ui-new/SettingsScreen.h
+++ b/examples/companion_radio/ui-new/SettingsScreen.h
@@ -66,6 +66,9 @@ class SettingsScreen : public UIScreen {
     DEVICE_NAME,
     TIMEZONE,
     LOW_BAT,
+#ifdef ADC_MULTIPLIER
+    ADC_MULT,
+#endif
 #if ENV_INCLUDE_GPS == 1
     GPS_DUTY_CYCLE,
 #endif
@@ -76,7 +79,7 @@ class SettingsScreen : public UIScreen {
     KEYBOARD_TYPE,
     KEYBOARD_MAIN_ALPHABET,
     KEYBOARD_ALPHABET,
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
     KEYBOARD_CARDKB_COMPACT,
 #endif
     // Contacts section
@@ -525,7 +528,22 @@ class SettingsScreen : public UIScreen {
         display.setCursor(xc, y);
         display.print(buf);
       }
-    } else if (item == CUSTOM_SF) {
+        }
+#ifdef ADC_MULTIPLIER
+    else if (item == ADC_MULT) {
+      display.print("ADC Mult");
+      int xc = valCol(display);
+      if (sel && _adc_ed.active) {
+        _adc_ed.render(display, xc, y);
+      } else {
+        char buf[10];
+        snprintf(buf, sizeof(buf), "%.3f", board.getAdcMultiplier());
+        display.setCursor(xc, y);
+        display.print(buf);
+      }
+    }
+#endif
+    else if (item == CUSTOM_SF) {
       display.print("SF");
       char buf[6];
       snprintf(buf, sizeof(buf), "%d", p ? (int)p->sf : 0);
@@ -605,7 +623,7 @@ class SettingsScreen : public UIScreen {
       display.print("Additional");
       display.setCursor(valCol(display), y);
       display.print(NodePrefs::keyboardAlphabetLabel(p ? p->keyboard_alt_alphabet : 0));
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
     } else if (item == KEYBOARD_CARDKB_COMPACT) {
       display.print("Ext. KB");
       display.setCursor(valCol(display), y);
@@ -689,6 +707,9 @@ class SettingsScreen : public UIScreen {
   // Manual radio-parameter editing (digit-by-digit Freq editor + SF/BW/CR
   // stepping), shared with Tools › Repeater — see RadioParamsEditor.h.
   RadioParamsEditor _editor;
+  #ifdef ADC_MULTIPLIER
+  DigitEditor _adc_ed;
+#endif
 
 public:
   SettingsScreen(UITask* task, KeyboardWidget* kb)
@@ -776,6 +797,16 @@ public:
       if (_editor.handleFreqInput(c) && p) { _task->applyRadioParams(); _dirty = true; }
       return true;
     }
+    #ifdef ADC_MULTIPLIER
+    if (_adc_ed.active) {
+      DigitEditor::Result r = _adc_ed.handleInput(c);
+      if (r == DigitEditor::DONE) {
+        board.setAdcMultiplier(_adc_ed.value);
+        if (p) { p->adc_multiplier = _adc_ed.value; _dirty = true; }
+      }
+      return true;
+    }
+#endif
 
     // Keyboard editing mode for naming a new saved preset
     if (_picker.saving) {
@@ -903,6 +934,12 @@ public:
       _editor.beginFreq(p->freq, min_mhz, max_mhz);
       return true;
     }
+    #ifdef ADC_MULTIPLIER
+    if (_selected == ADC_MULT && enter) {
+      _adc_ed.begin(board.getAdcMultiplier(), 0.0f, 10.0f, 2, 3);
+      return true;
+    }
+#endif
     int dir = right ? 1 : (left ? -1 : 0);
     if (_selected == CUSTOM_SF && p && dir && RadioParamsEditor::stepSF(p->sf, dir)) { _task->applyRadioParams(); _dirty = true; return true; }
     if (_selected == CUSTOM_BW && p && dir && RadioParamsEditor::stepBW(p->bw, dir)) { _task->applyRadioParams(); _dirty = true; return true; }
@@ -993,7 +1030,7 @@ public:
       _dirty = true;
       return true;
     }
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
     if (_selected == KEYBOARD_CARDKB_COMPACT && p && (left || right || enter)) {
       p->keyboard_cardkb_compact ^= 1;
       _dirty = true;

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -13,6 +13,13 @@
 #ifndef AUTO_OFF_MILLIS
   #define AUTO_OFF_MILLIS     15000   // 15 seconds
 #endif
+// Which I2C bus the CardKB sits on. Most boards with a dedicated sensor bus
+// (CARDKB_WIRE) put an optional CardKB there. Boards that wire the CardKB onto the
+// same bus as their display (e.g. Promicro/Faketec, shared with the OLED)
+// define CARDKB_WIRE=Wire in their platformio.ini to override this.
+#ifndef CARDKB_WIRE
+  #define CARDKB_WIRE CARDKB_WIRE
+#endif
 // Upstream MeshCore version, shown on the splash screen. Most variants set it in
 // their platformio.ini; the ones that don't used to fail to compile this file
 // outright rather than fall back, which quietly made every ui-new env on those
@@ -1397,11 +1404,11 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   uint32_t aoff = autoOffMillis();
   _auto_off = millis() + (aoff > 0 ? aoff : AUTO_OFF_MILLIS);
 
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
-  // Wire1 is already brought up by sensors.begin() (EnvironmentSensorManager),
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
+  // CARDKB_WIRE is already brought up by sensors.begin() (EnvironmentSensorManager),
   // which runs before this -- just probe for a CardKB sitting on it.
-  Wire1.beginTransmission(0x5F);
-  _has_cardkb = (Wire1.endTransmission() == 0);
+  CARDKB_WIRE.beginTransmission(0x5F);
+  _has_cardkb = (CARDKB_WIRE.endTransmission() == 0);
 #endif
 
 #if defined(PIN_USER_BTN)
@@ -2104,7 +2111,7 @@ bool UITask::dequeueKey(char& c) {
   return true;
 }
 
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
 // CardKB's "fn" column (key_map in M5Stack's unit_CardKB.cpp): Fn+<physical
 // key> sends 0x80 + that key's row index, entirely disjoint from every other
 // code this UI recognises. Indexed by (raw - 0x80); non-letter slots (digits,
@@ -2117,7 +2124,7 @@ static const char CARDKB_FN_BASE[48] = {
 };
 #endif
 
-// Poll an optional CardKB (I2C keyboard, addr 0x5F) on Wire1/Grove, feeding
+// Poll an optional CardKB (I2C keyboard, addr 0x5F) on CARDKB_WIRE/Grove, feeding
 // the same key queue as every physical button. Most of its output needs no
 // translation at all: CardKB's own arrow/Enter/Esc byte codes are already
 // identical to this UI's KEY_LEFT/UP/DOWN/RIGHT/ENTER/CANCEL (0xB4-0xB7, 13,
@@ -2145,7 +2152,7 @@ static const char CARDKB_FN_BASE[48] = {
 // once), so _cardkb_last_raw debounces it into one press per physical
 // keypress, same as a MomentaryButton's CLICK event.
 void UITask::pollCardKB() {
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
   if (!_has_cardkb) return;
   // No artificial throttle: unlike a MomentaryButton (BUTTON_USE_INTERRUPTS
   // latches every edge in an ISR ring buffer, so it survives a blocking e-ink
@@ -2156,9 +2163,9 @@ void UITask::pollCardKB() {
   // Polling every loop() iteration (same as a digital button's check(), which
   // has no throttle either) just shrinks that miss window down to exactly the
   // render() duration instead of render()+30ms.
-  Wire1.requestFrom(0x5F, 1);
-  if (!Wire1.available()) return;
-  uint8_t raw = Wire1.read();
+  CARDKB_WIRE.requestFrom(0x5F, 1);
+  if (!CARDKB_WIRE.available()) return;
+  uint8_t raw = CARDKB_WIRE.read();
   if (raw == _cardkb_last_raw) return;   // still held (or still released) -- no new edge
   _cardkb_last_raw = raw;
   if (raw == 0) return;   // key just released, nothing to enqueue
@@ -2480,7 +2487,7 @@ void UITask::loop() {
       }
       // Hint popup at bottom (like alert style)
       _display->setTextSize(1);
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
       const char* hint = _lock_seq_count == 0 ? (_has_cardkb ? "Back+3xEnter/Fn+Esc" : "Hold Back + 3xEnter") :
                          _lock_seq_count == 1 ? "Enter x2 more..."   : "Enter x1 more...";
 #else

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -198,7 +198,7 @@ class UITask : public AbstractUITask {
   // EnvironmentSensorManager) as the "this board has a second I2C bus" gate,
   // rather than a new board-specific pin define. No-op entirely on boards
   // without that bus, or when nothing ACKs 0x5F at boot.
-#if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)
+#if (defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL)) || defined(CARDKB_ENABLE)
   bool     _has_cardkb = false;
   // CardKB is level-triggered, not edge-triggered -- it keeps returning the
   // same byte for as long as the physical key is held, not just once. Track

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -42,7 +42,10 @@ public:
   // y where list items begin: a 2px breathing gap below the header separator so
   // the first row doesn't touch the line (matches the hand-rolled hdr+2 used by
   // the graphical screens).
-  int listStart()            const { return headerH() + 2; }
+  #ifndef LIST_START_EXTRA_PAD
+     #define LIST_START_EXTRA_PAD 0
+   #endif
+     int listStart()            const { return headerH() + 2 + LIST_START_EXTRA_PAD; }
   int listVisible(int itemH) const { return (height() - listStart()) / itemH; }
   int listVisible()          const { return listVisible(lineStep()); }
   // x where a right-side value column starts (leaves ~8 chars for the value)

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -145,6 +145,9 @@ build_flags = ${Promicro.build_flags}
   -D DISPLAY_CLASS=SSD1306Display
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
+  -D CARDKB_ENABLE=1
+  -D CARDKB_WIRE=Wire
+  -D LIST_START_EXTRA_PAD=4
 build_src_filter = ${Promicro.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<helpers/ui/SSD1306Display.cpp>


### PR DESCRIPTION
### **Summary**

Disclaimer: I mostly vibe coded this using Claude, but it is tested and works.

A set of fixes and additions from bringing up a Faketec (ProMicro nRF52840) board with an M5Stack CardKB and a dual-color (yellow/blue) SSD1306 OLED. Two general bug fixes affecting any board with ADC_MULTIPLIER defined, plus three Promicro/Faketec-specific additions that are opt-in and have no effect on other boards.

Tested on real hardware (Faketec v4, ProMicro nRF52840 + HT-RA62), ProMicro_companion_radio_ble build.

### Bug fixes (general, not Promicro-specific)
adc.multiplier was unreachable on companion radio firmware

Companion radio's get/set custom-var commands (CMD_GET_CUSTOM_VARS / CMD_SET_CUSTOM_VAR) only ever routed through the sensor settings registry. adc.multiplier is board-level calibration, not a sensor setting, so get adc.multiplier returned "Unknown var" and set adc.multiplier <x> was silently rejected — even though board.getAdcMultiplier() / setAdcMultiplier() were already implemented and working correctly on repeater/room-server firmware.

Fix: special-case adc.multiplier in both handlers to call the board-level functions directly, same pattern already used for the GPS custom-var special-casing right below it.

Affects: any board defining ADC_MULTIPLIER (currently Promicro; presumably others), running companion radio firmware.

adc.multiplier didn't persist across reboot

Even after the above fix, set adc.multiplier <x> only updated the live in-memory value — NodePrefs had no field for it, so a reboot silently reverted to the compiled-in default. Repeater firmware already persists this; companion radio didn't.

Fix:

New float adc_multiplier field in NodePrefs, schema sentinel bumped 0xC0DE0023 → 0xC0DE0024
Load/save wired into DataStore.cpp's existing append-only tail pattern
Applied at boot via board.setAdcMultiplier(), right alongside the existing pref-sanitization block (NaN/inf guard included, same reasoning as the existing freq/bw guards)
set adc.multiplier now writes into NodePrefs and calls savePrefs() in addition to applying the live value

Affects: same boards as above.

### Promicro/Faketec-specific additions (opt-in, no effect elsewhere)
CardKB support on boards where it shares the display's I2C bus

The existing CardKB auto-detection in UITask.cpp hardcoded Wire1 (a board's dedicated sensor bus). On Promicro/Faketec, the CardKB is commonly wired to the same bus as the OLED (Wire, the primary bus) rather than a second one — Wire1 there is unused and, on this variant, its pin assignment turned out to physically collide with the LoRa radio's SPI pins.

Fix: introduced a CARDKB_WIRE macro (defaults to Wire1, unchanged behaviour everywhere else) that boards can override in platformio.ini. Also broadened the #if defined(ENV_PIN_SDA) && defined(ENV_PIN_SCL) compile guards (in UITask.cpp/.h and SettingsScreen.h) to ... || defined(CARDKB_ENABLE), since CardKB-on-primary-bus boards don't necessarily have a second I2C bus at all.

Promicro's platformio.ini sets CARDKB_ENABLE=1 and CARDKB_WIRE=Wire.

On-device "ADC Mult" settings row

Settings › System now has an ADC Multiplier row (gated #ifdef ADC_MULTIPLIER) using the same digit-cursor DigitEditor widget already used for Freq — lets calibration be dialled in and saved on-device without needing the CLI.

Fix for OLED first-row clipping on dual-color displays

Cheap "yellow/blue" SSD1306 panels have a physical seam on the glass (~y=16) where the two colour regions meet. The shared list-rendering skeleton's first row landed right on that seam, visibly bisecting the top item of every submenu. Added an optional LIST_START_EXTRA_PAD build flag (defaults to 0, no change elsewhere) that nudges the first row down clear of the seam; Promicro sets it to 4.

### Notes for reviewers
Happy to split this into separate PRs (bug fixes vs. Promicro-specific) if that's easier to review — bundled here since they came out of one bring-up session on the same board.
The two general fixes were verified against meshcore-cli (get/set adc.multiplier, confirmed persisting across a real power cycle) as well as the new on-device menu.
LIST_START_EXTRA_PAD's value (4) was tuned empirically against one physical panel; other yellow/blue SSD1306 units may need a slightly different number given manufacturing tolerance on the seam position — it's a per-variant build flag for exactly that reason.